### PR TITLE
Add entity_name to validators call

### DIFF
--- a/indexer/analyzer_tasks.go
+++ b/indexer/analyzer_tasks.go
@@ -126,7 +126,7 @@ func (t *systemEventCreatorTask) getMissedBlocksSystemEvents(currHeightValidator
 			logger.Debug(fmt.Sprintf("total missed blocks for last %d blocks for address %s: %d", MaxValidatorSequences, validatorSequence.Address, totalMissedCount))
 
 			if totalMissedCount == MissedForMaxThreshold {
-				newSystemEvent, err := t.newSystemEvent(validatorSequence, model.SystemEventMissedMofN, systemEventRawData{
+				newSystemEvent, err := t.newSystemEvent(validatorSequence, model.SystemEventMissedNofM, systemEventRawData{
 					"threshold":               MissedForMaxThreshold,
 					"max_validator_sequences": MaxValidatorSequences,
 				})
@@ -142,7 +142,7 @@ func (t *systemEventCreatorTask) getMissedBlocksSystemEvents(currHeightValidator
 			logger.Debug(fmt.Sprintf("total missed blocks in a row for address %s: %d", validatorSequence.Address, missedInRowCount))
 
 			if missedInRowCount == MissedInRowThreshold {
-				newSystemEvent, err := t.newSystemEvent(validatorSequence, model.SystemEventMissedMInRow, systemEventRawData{
+				newSystemEvent, err := t.newSystemEvent(validatorSequence, model.SystemEventMissedNInRow, systemEventRawData{
 					"threshold": MissedInRowThreshold,
 				})
 				if err != nil {

--- a/indexer/analyzer_tasks.go
+++ b/indexer/analyzer_tasks.go
@@ -142,7 +142,7 @@ func (t *systemEventCreatorTask) getMissedBlocksSystemEvents(currHeightValidator
 			logger.Debug(fmt.Sprintf("total missed blocks in a row for address %s: %d", validatorSequence.Address, missedInRowCount))
 
 			if missedInRowCount == MissedInRowThreshold {
-				newSystemEvent, err := t.newSystemEvent(validatorSequence, model.SystemEventMissedNInRow, systemEventRawData{
+				newSystemEvent, err := t.newSystemEvent(validatorSequence, model.SystemEventMissedNConsecutive, systemEventRawData{
 					"threshold": MissedInRowThreshold,
 				})
 				if err != nil {

--- a/indexer/analyzer_tasks_test.go
+++ b/indexer/analyzer_tasks_test.go
@@ -395,7 +395,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 				},
 			},
 			expectedCount: 1,
-			expectedKinds: []model.SystemEventKind{model.SystemEventMissedMInRow},
+			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNInRow},
 		},
 		{
 			description:           "returns no missed_m_in_row system events when validator missed >= 3 blocks in a row in the past but current is validated",
@@ -438,7 +438,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 				},
 			},
 			expectedCount: 1,
-			expectedKinds: []model.SystemEventKind{model.SystemEventMissedMofN},
+			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNofM},
 		},
 		{
 			description:           "returns one missed_m_of_n system events when validator missed 3 blocks and max < last list",
@@ -461,7 +461,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 				},
 			},
 			expectedCount: 1,
-			expectedKinds: []model.SystemEventKind{model.SystemEventMissedMofN},
+			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNofM},
 		},
 		{
 			description:           "returns no missed_m_of_n system events when count of recent not validated > maxValidatorSequences",
@@ -575,7 +575,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 			},
 			errs:          []error{nil, store.ErrNotFound},
 			expectedCount: 1,
-			expectedKinds: []model.SystemEventKind{model.SystemEventMissedMofN},
+			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNofM},
 		},
 	}
 

--- a/indexer/analyzer_tasks_test.go
+++ b/indexer/analyzer_tasks_test.go
@@ -376,7 +376,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
-			description:           "returns one missed_m_in_row system events when validator missed >= 3 blocks in a row",
+			description:           "returns one missed_n_consecutive system events when validator missed >= 3 blocks in a row",
 			maxValidatorSequences: 5,
 			missedInRowThreshold:  3,
 			missedForMaxThreshold: 5,
@@ -395,10 +395,10 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 				},
 			},
 			expectedCount: 1,
-			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNInRow},
+			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNConsecutive},
 		},
 		{
-			description:           "returns no missed_m_in_row system events when validator missed >= 3 blocks in a row in the past but current is validated",
+			description:           "returns no missed_n_consecutive system events when validator missed >= 3 blocks in a row in the past but current is validated",
 			maxValidatorSequences: 5,
 			missedInRowThreshold:  3,
 			missedForMaxThreshold: 5,
@@ -419,7 +419,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
-			description:           "returns one missed_m_of_n system events when validator missed 3 blocks",
+			description:           "returns one missed_n_of_m system events when validator missed 3 blocks",
 			maxValidatorSequences: 5,
 			missedInRowThreshold:  50,
 			missedForMaxThreshold: 3,
@@ -441,7 +441,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNofM},
 		},
 		{
-			description:           "returns one missed_m_of_n system events when validator missed 3 blocks and max < last list",
+			description:           "returns one missed_n_of_m system events when validator missed 3 blocks and max < last list",
 			maxValidatorSequences: 3,
 			missedInRowThreshold:  50,
 			missedForMaxThreshold: 3,
@@ -464,7 +464,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 			expectedKinds: []model.SystemEventKind{model.SystemEventMissedNofM},
 		},
 		{
-			description:           "returns no missed_m_of_n system events when count of recent not validated > maxValidatorSequences",
+			description:           "returns no missed_n_of_m system events when count of recent not validated > maxValidatorSequences",
 			maxValidatorSequences: 5,
 			missedInRowThreshold:  50,
 			missedForMaxThreshold: 3,
@@ -486,7 +486,7 @@ func TestSystemEventCreatorTask_getMissedBlocksSystemEvents(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
-			description:           "returns no missed_m_of_n system events when current is validated",
+			description:           "returns no missed_n_of_m system events when current is validated",
 			maxValidatorSequences: 5,
 			missedInRowThreshold:  50,
 			missedForMaxThreshold: 3,

--- a/model/system_event.go
+++ b/model/system_event.go
@@ -11,8 +11,8 @@ const (
 	SystemEventCommissionChange3          SystemEventKind = "commission_change_3"
 	SystemEventJoinedActiveSet            SystemEventKind = "joined_active_set"
 	SystemEventLeftActiveSet              SystemEventKind = "left_active_set"
-	SystemEventMissedNInRow               SystemEventKind = "n_consecutive"
-	SystemEventMissedNofM                 SystemEventKind = "n_of_m"
+	SystemEventMissedNConsecutive         SystemEventKind = "missed_n_consecutive"
+	SystemEventMissedNofM                 SystemEventKind = "missed_n_of_m"
 )
 
 type SystemEventKind string

--- a/model/system_event.go
+++ b/model/system_event.go
@@ -11,8 +11,8 @@ const (
 	SystemEventCommissionChange3          SystemEventKind = "commission_change_3"
 	SystemEventJoinedActiveSet            SystemEventKind = "joined_active_set"
 	SystemEventLeftActiveSet              SystemEventKind = "left_active_set"
-	SystemEventMissedMInRow               SystemEventKind = "missed_m_in_row"
-	SystemEventMissedMofN                 SystemEventKind = "missed_m_of_n"
+	SystemEventMissedNInRow               SystemEventKind = "n_consecutive"
+	SystemEventMissedNofM                 SystemEventKind = "n_of_m"
 )
 
 type SystemEventKind string

--- a/usecase/validator/get_by_height.go
+++ b/usecase/validator/get_by_height.go
@@ -43,7 +43,7 @@ func (uc *getByHeightUseCase) Execute(height *int64) (SeqListView, error) {
 
 	aggs, err := uc.db.ValidatorAgg.GetAllForHeightGreaterThan(*height)
 	if err != nil {
-		return nil, err
+		return SeqListView{}, err
 	}
 
 	seqs, err := uc.db.ValidatorSeq.FindByHeight(*height)

--- a/usecase/validator/get_by_height.go
+++ b/usecase/validator/get_by_height.go
@@ -41,9 +41,12 @@ func (uc *getByHeightUseCase) Execute(height *int64) (*SeqListView, error) {
 		return nil, errors.New("height is not indexed yet")
 	}
 
-	seqs, err := uc.db.ValidatorSeq.FindByHeight(*height)
-	aggs, aggErr := uc.db.ValidatorAgg.GetAllForHeightGreaterThan(*height)
+	aggs, err := uc.db.ValidatorAgg.GetAllForHeightGreaterThan(*height)
+	if err != nil {
+		return nil, err
+	}
 
+	seqs, err := uc.db.ValidatorSeq.FindByHeight(*height)
 	if len(seqs) == 0 || err != nil {
 		indexingPipeline, err := indexer.NewPipeline(uc.cfg, uc.db, uc.client)
 		if err != nil {
@@ -61,10 +64,6 @@ func (uc *getByHeightUseCase) Execute(height *int64) (*SeqListView, error) {
 		}
 
 		seqs = payload.NewValidatorSequences
-		if len(aggs) == 0 || aggErr != nil {
-			aggs = payload.NewAggregatedValidators
-
-		}
 	}
 
 	return ToSeqListView(seqs, aggs), nil

--- a/usecase/validator/views.go
+++ b/usecase/validator/views.go
@@ -69,15 +69,22 @@ type SeqListItem struct {
 	AsValidatorHeight   int64          `json:"as_validator_height"`
 	ProposedHeight      int64          `json:"proposed_height"`
 	PrecommitValidated  *bool          `json:"precommit_validated"`
+	EntityName          string         `json:"entity_name"`
 }
 
 type SeqListView struct {
 	Items []SeqListItem `json:"items"`
 }
 
-func ToSeqListView(validatorSeqs []model.ValidatorSeq) *SeqListView {
+func ToSeqListView(validatorSeqs []model.ValidatorSeq, validatorAggs []model.ValidatorAgg) *SeqListView {
+	nameLookup := make(map[string]string)
+	for _, agg := range validatorAggs {
+		nameLookup[agg.Address] = agg.EntityName
+	}
+
 	var items []SeqListItem
 	for _, m := range validatorSeqs {
+
 		item := SeqListItem{
 			Sequence: m.Sequence,
 
@@ -87,6 +94,10 @@ func ToSeqListView(validatorSeqs []model.ValidatorSeq) *SeqListView {
 			TotalShares:         m.TotalShares,
 			ActiveEscrowBalance: m.ActiveEscrowBalance,
 			PrecommitValidated:  m.PrecommitValidated,
+		}
+
+		if val, ok := nameLookup[m.Address]; ok {
+			item.EntityName = val
 		}
 
 		items = append(items, item)

--- a/usecase/validator/views.go
+++ b/usecase/validator/views.go
@@ -76,7 +76,7 @@ type SeqListView struct {
 	Items []SeqListItem `json:"items"`
 }
 
-func ToSeqListView(validatorSeqs []model.ValidatorSeq, validatorAggs []model.ValidatorAgg) *SeqListView {
+func ToSeqListView(validatorSeqs []model.ValidatorSeq, validatorAggs []model.ValidatorAgg) SeqListView {
 	nameLookup := make(map[string]string)
 	for _, agg := range validatorAggs {
 		nameLookup[agg.Address] = agg.EntityName
@@ -103,7 +103,7 @@ func ToSeqListView(validatorSeqs []model.ValidatorSeq, validatorAggs []model.Val
 		items = append(items, item)
 	}
 
-	return &SeqListView{
+	return SeqListView{
 		Items: items,
 	}
 }


### PR DESCRIPTION
- Adds field `entity_name` to `/validators?height` call
- updates event kinds to be consistent with hubble