### PR TITLE
Fix config

### DIFF
--- a/indexer/aggregator_tasks_test.go
+++ b/indexer/aggregator_tasks_test.go
@@ -389,7 +389,7 @@ func TestValidatorAggCreatorTask_Run(t *testing.T) {
 				dbMock.EXPECT().FindByEntityUID(key).Return(returnVal, nil).Times(1)
 
 				validator := updateValidatorAgg(returnVal, raw, payload)
-				validator.RecentTendermintAddress = raw.GetAddress()
+				validator.RecentTendermintAddress = raw.GetTendermintAddress()
 
 				if parsed, ok := tt.parsed[raw.Address]; ok {
 					updateParsedValidatorAgg(validator, parsed, payload, false)

--- a/indexer/config_parser.go
+++ b/indexer/config_parser.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/figment-networks/indexing-engine/pipeline"
 	"io/ioutil"
+
+	"github.com/figment-networks/indexing-engine/pipeline"
 )
 
 const (
-	IndexTargetBlockSequences = iota + 1
+	IndexTargetBlockSequences = iota + int64(1)
 	IndexTargetValidatorSequences
 	IndexTargetValidatorAggregates
 	IndexTargetSystemEvents

--- a/indexer/config_parser.go
+++ b/indexer/config_parser.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	IndexTargetBlockSequences = iota + int64(1)
+	IndexTargetBlockSequences = iota + 1
 	IndexTargetValidatorSequences
 	IndexTargetValidatorAggregates
 	IndexTargetSystemEvents

--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -279,25 +279,19 @@ func (o *indexingPipeline) canRunBackfill(isParallel bool) error {
 }
 
 type RunConfig struct {
-	Height           int64
-	DesiredVersionID *int64
-	DesiredTargetID  *int64
-	Dry              bool
+	Height            int64
+	DesiredVersionIDs []int64
+	DesiredTargetIDs  []int64
+	Dry               bool
 }
 
 // Run runs pipeline just for one height
 func (o *indexingPipeline) Run(ctx context.Context, runCfg RunConfig) (*payload, error) {
 	pipelineOptionsCreator := &pipelineOptionsCreator{
-		configParser: o.configParser,
-		dry:          runCfg.Dry,
-	}
-
-	if runCfg.DesiredVersionID != nil {
-		pipelineOptionsCreator.desiredVersionIds = []int64{*runCfg.DesiredVersionID}
-	}
-
-	if runCfg.DesiredTargetID != nil {
-		pipelineOptionsCreator.desiredTargetIds = []int64{*runCfg.DesiredTargetID}
+		configParser:      o.configParser,
+		dry:               runCfg.Dry,
+		desiredVersionIds: runCfg.DesiredVersionIDs,
+		desiredTargetIds:  runCfg.DesiredTargetIDs,
 	}
 
 	pipelineOptions, err := pipelineOptionsCreator.parse()
@@ -305,7 +299,11 @@ func (o *indexingPipeline) Run(ctx context.Context, runCfg RunConfig) (*payload,
 		return nil, err
 	}
 
-	logger.Info(fmt.Sprintf("running pipeline... [height=%d] [version=%d]", runCfg.Height, runCfg.DesiredTargetID))
+	logger.Info("running pipeline...",
+		logger.Field("height", runCfg.Height),
+		logger.Field("versions", runCfg.DesiredVersionIDs),
+		logger.Field("targets", runCfg.DesiredTargetIDs),
+	)
 
 	runPayload, err := o.pipeline.Run(ctx, runCfg.Height, pipelineOptions)
 	if err != nil {

--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -280,19 +280,26 @@ func (o *indexingPipeline) canRunBackfill(isParallel bool) error {
 
 type RunConfig struct {
 	Height           int64
-	DesiredVersionID int64
-	DesiredTargetID  int64
+	DesiredVersionID *int64
+	DesiredTargetID  *int64
 	Dry              bool
 }
 
 // Run runs pipeline just for one height
 func (o *indexingPipeline) Run(ctx context.Context, runCfg RunConfig) (*payload, error) {
 	pipelineOptionsCreator := &pipelineOptionsCreator{
-		configParser:      o.configParser,
-		dry:               runCfg.Dry,
-		desiredVersionIds: []int64{runCfg.DesiredVersionID},
-		desiredTargetIds:  []int64{runCfg.DesiredTargetID},
+		configParser: o.configParser,
+		dry:          runCfg.Dry,
 	}
+
+	if runCfg.DesiredVersionID != nil {
+		pipelineOptionsCreator.desiredVersionIds = []int64{*runCfg.DesiredVersionID}
+	}
+
+	if runCfg.DesiredTargetID != nil {
+		pipelineOptionsCreator.desiredTargetIds = []int64{*runCfg.DesiredTargetID}
+	}
+
 	pipelineOptions, err := pipelineOptionsCreator.parse()
 	if err != nil {
 		return nil, err

--- a/usecase/validator/get_by_height.go
+++ b/usecase/validator/get_by_height.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+
 	"github.com/figment-networks/oasishub-indexer/client"
 	"github.com/figment-networks/oasishub-indexer/config"
 	"github.com/figment-networks/oasishub-indexer/indexer"
@@ -42,15 +43,16 @@ func (uc *getByHeightUseCase) Execute(height *int64) (*SeqListView, error) {
 
 	models, err := uc.db.ValidatorSeq.FindByHeight(*height)
 	if len(models) == 0 || err != nil {
-		indexingPipeline , err := indexer.NewPipeline(uc.cfg, uc.db, uc.client)
+		indexingPipeline, err := indexer.NewPipeline(uc.cfg, uc.db, uc.client)
 		if err != nil {
 			return nil, err
 		}
 
+		targetId := indexer.IndexTargetValidatorSequences
 		ctx := context.Background()
 		payload, err := indexingPipeline.Run(ctx, indexer.RunConfig{
 			Height:          *height,
-			DesiredTargetID: indexer.IndexTargetValidatorSequences,
+			DesiredTargetID: &targetId,
 			Dry:             true,
 		})
 		if err != nil {

--- a/usecase/validator/get_by_height.go
+++ b/usecase/validator/get_by_height.go
@@ -48,12 +48,11 @@ func (uc *getByHeightUseCase) Execute(height *int64) (*SeqListView, error) {
 			return nil, err
 		}
 
-		targetId := indexer.IndexTargetValidatorSequences
 		ctx := context.Background()
 		payload, err := indexingPipeline.Run(ctx, indexer.RunConfig{
-			Height:          *height,
-			DesiredTargetID: &targetId,
-			Dry:             true,
+			Height:           *height,
+			DesiredTargetIDs: []int64{indexer.IndexTargetValidatorSequences},
+			Dry:              true,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When making calls to `/validator?height` for heights that have been purged from db, api was responding with no data.

Looking at logs, I saw this error:
```{"level":"error","time":"2020-08-14T12:40:10.731-0400","msg":"[ERROR: version 0 not found]"} ```

Issue was `DesiredTargetID` in `RunConfig` was unintentionally being set to zero.