### PR TITLE
Implement /account/:address/summaries call

### DIFF
--- a/model/syncable.go
+++ b/model/syncable.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	"github.com/figment-networks/oasishub-indexer/types"
 	"time"
+
+	"github.com/figment-networks/oasishub-indexer/types"
 )
 
 const (
@@ -27,7 +28,7 @@ type Syncable struct {
 	Duration     time.Duration  `json:"duration"`
 }
 
-func (Syncable) TableName() string {
+func (s *Syncable) TableName() string {
 	return "syncables"
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -19,6 +19,7 @@ func (s *Server) setupRoutes() {
 	s.engine.GET("/debonding_delegations", s.handlers.GetDebondingDelegationsByHeight.Handle)
 	s.engine.GET("/debonding_delegations/:address", s.handlers.GetDebondingDelegationsByAddress.Handle)
 	s.engine.GET("/account/:address", s.handlers.GetAccountByAddress.Handle)
+	s.engine.GET("/account/:address/summaries", s.handlers.GetAccountSummaries.Handle)
 	s.engine.GET("/system_events/:address", s.handlers.GetSystemEventsForAddress.Handle)
 	s.engine.GET("/balance/:address", s.handlers.GetBalanceForAddress.Handle)
 

--- a/usecase/account/get_summaries.go
+++ b/usecase/account/get_summaries.go
@@ -49,7 +49,7 @@ func (uc *getSummariesUseCase) Execute(address string, start, end time.Time) (Da
 			account:  resp.GetAccount(),
 		})
 
-		dayStart = dayStart.Add(time.Hour * 1)
+		dayStart = dayStart.Add(time.Hour * 24)
 		if dayStart.After(end) {
 			dayStart = end
 		}

--- a/usecase/account/get_summaries.go
+++ b/usecase/account/get_summaries.go
@@ -1,0 +1,59 @@
+package account
+
+import (
+	"time"
+
+	"github.com/figment-networks/oasis-rpc-proxy/grpc/account/accountpb"
+	"github.com/figment-networks/oasishub-indexer/client"
+	"github.com/figment-networks/oasishub-indexer/store"
+)
+
+type getSummariesUseCase struct {
+	db     *store.Store
+	client *client.Client
+}
+
+func NewGetSummariesUseCase(db *store.Store, c *client.Client) *getSummariesUseCase {
+	return &getSummariesUseCase{
+		db:     db,
+		client: c,
+	}
+}
+
+type dataRow struct {
+	dayStart time.Time
+	account  *accountpb.Account
+}
+
+func (uc *getSummariesUseCase) Execute(address string, start, end time.Time) (DailyBalanceViewResult, error) {
+	dayStart := start
+	var rows []dataRow
+
+	for {
+		if dayStart == end {
+			break
+		}
+
+		syncable, err := uc.db.Syncables.GetSyncableForMinTime(dayStart)
+		if err != nil {
+			return DailyBalanceViewResult{}, err
+		}
+
+		resp, err := uc.client.Account.GetByAddress(address, syncable.Height)
+		if err != nil {
+			return DailyBalanceViewResult{}, err
+		}
+
+		rows = append(rows, dataRow{
+			dayStart: dayStart,
+			account:  resp.GetAccount(),
+		})
+
+		dayStart = dayStart.Add(time.Hour * 1)
+		if dayStart.After(end) {
+			dayStart = end
+		}
+	}
+
+	return toDailyBalanceViewResult(rows), nil
+}

--- a/usecase/account/get_summaries_http_handler.go
+++ b/usecase/account/get_summaries_http_handler.go
@@ -1,0 +1,66 @@
+package account
+
+import (
+	"time"
+
+	"github.com/figment-networks/oasishub-indexer/client"
+	"github.com/figment-networks/oasishub-indexer/store"
+	"github.com/figment-networks/oasishub-indexer/types"
+	"github.com/figment-networks/oasishub-indexer/usecase/http"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+)
+
+var (
+	_ types.HttpHandler = (*getSummariesHttpHandler)(nil)
+)
+
+type getSummariesHttpHandler struct {
+	db     *store.Store
+	client *client.Client
+
+	useCase *getSummariesUseCase
+}
+
+func NewGetSummariesHttpHandler(db *store.Store, c *client.Client) *getSummariesHttpHandler {
+	return &getSummariesHttpHandler{
+		db:     db,
+		client: c,
+	}
+}
+
+type uriParams struct {
+	Address string `uri:"address" binding:"required"`
+}
+type queryParams struct {
+	Start time.Time `form:"start" binding:"required" time_format:"2006-01-02 15:04:05"`
+	End   time.Time `form:"end" binding:"required" time_format:"2006-01-02 15:04:05"`
+}
+
+func (h *getSummariesHttpHandler) Handle(c *gin.Context) {
+	var uri uriParams
+	if err := c.ShouldBindUri(&uri); err != nil {
+		http.BadRequest(c, errors.New("invalid address"))
+		return
+	}
+
+	var params queryParams
+	if err := c.ShouldBindQuery(&params); err != nil {
+		http.BadRequest(c, errors.New("invalid start and/or end params: must be in format \"2006-01-02 15:04:05\""))
+		return
+	}
+
+	resp, err := h.getUseCase().Execute(uri.Address, params.Start, params.End)
+	if http.ShouldReturn(c, err) {
+		return
+	}
+
+	http.JsonOK(c, resp)
+}
+
+func (h *getSummariesHttpHandler) getUseCase() *getSummariesUseCase {
+	if h.useCase == nil {
+		h.useCase = NewGetSummariesUseCase(h.db, h.client)
+	}
+	return h.useCase
+}

--- a/usecase/account/views.go
+++ b/usecase/account/views.go
@@ -1,6 +1,8 @@
 package account
 
 import (
+	"time"
+
 	"github.com/figment-networks/oasis-rpc-proxy/grpc/account/accountpb"
 	"github.com/figment-networks/oasishub-indexer/types"
 )
@@ -23,4 +25,30 @@ func ToDetailsView(rawAccount *accountpb.Account) *DetailsView {
 		EscrowDebondingBalance:     types.NewQuantityFromBytes(rawAccount.GetEscrow().GetDebonding().GetBalance()),
 		EscrowDebondingTotalShares: types.NewQuantityFromBytes(rawAccount.GetEscrow().GetDebonding().GetTotalShares()),
 	}
+}
+
+type DailyBalanceViewResult struct {
+	Result []DailyBalanceView `json:"result"`
+}
+type DailyBalanceView struct {
+	TimeBucket time.Time   `json:"time_bucket"`
+	Balance    DetailsView `json:"balance"`
+}
+
+func toDailyBalanceViewResult(data []dataRow) DailyBalanceViewResult {
+	var summaries []DailyBalanceView
+	for _, row := range data {
+		summaries = append(summaries, DailyBalanceView{
+			TimeBucket: row.dayStart,
+			Balance: DetailsView{
+				GeneralBalance:             types.NewQuantityFromBytes(row.account.GetGeneral().GetBalance()),
+				GeneralNonce:               row.account.GetGeneral().GetNonce(),
+				EscrowActiveBalance:        types.NewQuantityFromBytes(row.account.GetEscrow().GetActive().GetBalance()),
+				EscrowActiveTotalShares:    types.NewQuantityFromBytes(row.account.GetEscrow().GetActive().GetBalance()),
+				EscrowDebondingBalance:     types.NewQuantityFromBytes(row.account.GetEscrow().GetDebonding().GetBalance()),
+				EscrowDebondingTotalShares: types.NewQuantityFromBytes(row.account.GetEscrow().GetDebonding().GetTotalShares()),
+			},
+		})
+	}
+	return DailyBalanceViewResult{Result: summaries}
 }

--- a/usecase/http_handlers.go
+++ b/usecase/http_handlers.go
@@ -26,6 +26,7 @@ func NewHttpHandlers(cfg *config.Config, db *store.Store, c *client.Client) *Htt
 		GetBlockTimes:                    block.NewGetBlockTimesHttpHandler(db, c),
 		GetBlockSummary:                  block.NewGetBlockSummaryHttpHandler(db, c),
 		GetAccountByAddress:              account.NewGetByAddressHttpHandler(db, c),
+		GetAccountSummaries:              account.NewGetSummariesHttpHandler(db, c),
 		GetDebondingDelegationsByHeight:  debondingdelegation.NewGetByHeightHttpHandler(db, c),
 		GetDebondingDelegationsByAddress: debondingdelegation.NewGetByAddressHttpHandler(db, c),
 		GetDelegationsByHeight:           delegation.NewGetByHeightHttpHandler(db, c),
@@ -49,6 +50,7 @@ type HttpHandlers struct {
 	GetBlockSummary                  types.HttpHandler
 	GetBlockByHeight                 types.HttpHandler
 	GetAccountByAddress              types.HttpHandler
+	GetAccountSummaries              types.HttpHandler
 	GetDebondingDelegationsByHeight  types.HttpHandler
 	GetDebondingDelegationsByAddress types.HttpHandler
 	GetDelegationsByHeight           types.HttpHandler


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=57ff1e911dfa41479009e6723c68576d&p=24c85d23b69f47ce8ffd1e88cc097f72)

Adds call `GET /account/:address/summaries?start=2020-11-21 01:50:00&end=2020-11-27 01:50:00`

`start` and `end` param are in the format `2020-11-21 01:50:00` in UTC. Balances for the account are fetched  in 24h time buckets starting from start param time. Balance is fetched from block closest to `time_bucket` where `time_bucket >= time`.

```
{
    "result": [
        {
            "time_bucket": "2020-11-21T01:50:00Z",
            "balance": {
                "general_balance": 7034,
                "general_nonce": 0,
                "escrow_active_balance": 102002455347898,
                "escrow_active_total_shares": 102002455347898,
                "escrow_debonding_balance": 0,
                "escrow_debonding_total_shares": 0
            }
        },
        {
            "time_bucket": "2020-11-22T01:50:00Z",
            "balance": {
                "general_balance": 7034,
                "general_nonce": 0,
                "escrow_active_balance": 102002455347898,
                "escrow_active_total_shares": 102002455347898,
                "escrow_debonding_balance": 0,
                "escrow_debonding_total_shares": 0
            }
        },
        {
            "time_bucket": "2020-11-23T01:50:00Z",
            "balance": {
                "general_balance": 7041,
                "general_nonce": 0,
                "escrow_active_balance": 102004578018993,
                "escrow_active_total_shares": 102004578018993,
                "escrow_debonding_balance": 0,
                "escrow_debonding_total_shares": 0
            }
        },
        {
            "time_bucket": "2020-11-24T01:50:00Z",
            "balance": {
                "general_balance": 7041,
                "general_nonce": 0,
                "escrow_active_balance": 102008823493703,
                "escrow_active_total_shares": 102008823493703,
                "escrow_debonding_balance": 0,
                "escrow_debonding_total_shares": 0
            }
        },
        {
            "time_bucket": "2020-11-25T01:50:00Z",
            "balance": {
                "general_balance": 7041,
                "general_nonce": 0,
                "escrow_active_balance": 102008823493703,
                "escrow_active_total_shares": 102008823493703,
                "escrow_debonding_balance": 0,
                "escrow_debonding_total_shares": 0
            }
        },
        {
            "time_bucket": "2020-11-26T01:50:00Z",
            "balance": {
                "general_balance": 7090,
                "general_nonce": 0,
                "escrow_active_balance": 102013069145111,
                "escrow_active_total_shares": 102013069145111,
                "escrow_debonding_balance": 0,
                "escrow_debonding_total_shares": 0
            }
        }
    ]
}
```