### PR TITLE
Comment out events fetching

### DIFF
--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -66,7 +66,7 @@ func NewPipeline(cfg *config.Config, db *store.Store, client *client.Client) (*i
 		pipeline.RetryingTask(NewStateFetcherTask(client.State), isTransient, 3),
 		pipeline.RetryingTask(NewValidatorFetcherTask(client.Validator), isTransient, 3),
 		pipeline.RetryingTask(NewTransactionFetcherTask(client.Transaction), isTransient, 3),
-		pipeline.RetryingTask(NewEventsFetcherTask(client.Event), isTransient, 3),
+		// pipeline.RetryingTask(NewEventsFetcherTask(client.Event), isTransient, 3),
 	)
 
 	// Set parser stage


### PR DESCRIPTION
When we call `GetEvents` for height 3661655, we get this error:
 ```
 staking: corrupt AddEscrow event: cbor: found unknown field at map element index 0
 ```

indexer is currently stuck at height  3661655. Since we only need events for reward calculations, I'm temporarily disabling event fetching so that indexer can proceed and hubble can catch up. The cbor issue started happening after the latest node upgrade, and I reached out to oasis team about the issue. When this is fixed, we will need to run a backfill process for rewards starting from problem height.

[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=1e7503c4391d4b2f993b699ce0480afa)