### PR TITLE
Resync cmd

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -35,7 +35,7 @@ func runCmd(cfg *config.Config, flags Flags) error {
 	case "indexer:backfill":
 		cmdHandlers.IndexerBackfill.Handle(ctx, flags.parallel, flags.force)
 	case "indexer:reindex":
-		cmdHandlers.IndexerReindex.Handle(ctx, flags.parallel, flags.force, flags.startReindexHeight, flags.endReindexHeight, flags.targetIds)
+		cmdHandlers.IndexerReindex.Handle(ctx, flags.parallel, flags.startReindexHeight, flags.endReindexHeight, flags.targetIds)
 	case "indexer:summarize":
 		cmdHandlers.IndexerSummarize.Handle(ctx)
 	case "indexer:purge":

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -34,6 +34,8 @@ func runCmd(cfg *config.Config, flags Flags) error {
 		cmdHandlers.IndexerIndex.Handle(ctx, flags.batchSize)
 	case "indexer:backfill":
 		cmdHandlers.IndexerBackfill.Handle(ctx, flags.parallel, flags.force)
+	case "indexer:reindex":
+		cmdHandlers.IndexerReindex.Handle(ctx, flags.parallel, flags.force, flags.startReindexHeight, flags.endReindexHeight, flags.targetIds)
 	case "indexer:summarize":
 		cmdHandlers.IndexerSummarize.Handle(ctx)
 	case "indexer:purge":

--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -281,8 +281,7 @@ func (o *indexingPipeline) canRunBackfill(isParallel bool) error {
 }
 
 type ReindexConfig struct {
-	Parallel bool
-	// Force       bool
+	Parallel    bool
 	StartHeight int64
 	EndHeight   int64
 	TargetIds   []int64
@@ -306,11 +305,6 @@ func (o *indexingPipeline) Reindex(ctx context.Context, cfg ReindexConfig) error
 	if cfg.Parallel {
 		kind = model.ReportKindParallelReindex
 	}
-	// if cfg.Force {
-	// 	if err := o.db.Reports.DeleteByKinds([]model.ReportKind{model.ReportKindParallelReindex, model.ReportKindSequentialReindex}); err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	reportCreator := &reportCreator{
 		kind:         kind,

--- a/indexer/source_reindex.go
+++ b/indexer/source_reindex.go
@@ -1,0 +1,100 @@
+package indexer
+
+import (
+	"context"
+
+	"github.com/figment-networks/indexing-engine/pipeline"
+	"github.com/figment-networks/oasishub-indexer/config"
+	"github.com/figment-networks/oasishub-indexer/model"
+)
+
+var (
+	_ pipeline.Source = (*reindexSource)(nil)
+)
+
+type ReindexSourceStore interface {
+	FindMostRecent() (*model.Syncable, error)
+}
+
+func NewReindexSource(cfg *config.Config, db ReindexSourceStore, startHeight, endHeight int64) (*reindexSource, error) {
+	src := &reindexSource{
+		cfg: cfg,
+		db:  db,
+	}
+
+	if err := src.init(startHeight, endHeight); err != nil {
+		return nil, err
+	}
+
+	return src, nil
+}
+
+type reindexSource struct {
+	cfg *config.Config
+	db  ReindexSourceStore
+
+	startHeight   int64
+	currentHeight int64
+	endHeight     int64
+	err           error
+}
+
+func (s *reindexSource) Next(context.Context, pipeline.Payload) bool {
+	if s.err == nil && s.currentHeight < s.endHeight {
+		s.currentHeight = s.currentHeight + 1
+		return true
+	}
+	return false
+}
+
+func (s *reindexSource) Skip(stageName pipeline.StageName) bool {
+	return false
+}
+
+func (s *reindexSource) Current() int64 {
+	return s.currentHeight
+}
+
+func (s *reindexSource) Err() error {
+	return s.err
+}
+
+func (s *reindexSource) Len() int64 {
+	return s.endHeight - s.startHeight + 1
+}
+
+func (s *reindexSource) init(startHeight, endHeight int64) error {
+	if err := s.setStartHeight(startHeight); err != nil {
+		return err
+	}
+	if err := s.setEndHeight(endHeight); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *reindexSource) setStartHeight(startHeight int64) error {
+	startH := startHeight
+	if startH < 1 {
+		startH = 1
+	}
+
+	s.currentHeight = startH
+	s.startHeight = startH
+	return nil
+}
+
+func (s *reindexSource) setEndHeight(endHeight int64) error {
+	if endHeight > 0 {
+		s.endHeight = endHeight
+		return nil
+	}
+
+	syncable, err := s.db.FindMostRecent()
+	if err != nil {
+		return err
+	}
+
+	s.endHeight = syncable.Height
+	return nil
+}

--- a/store/balance_events_store.go
+++ b/store/balance_events_store.go
@@ -103,7 +103,8 @@ func (s *balanceEventsStore) Summarize(interval types.SummaryInterval, activityP
 				if err != nil {
 					return nil, err
 				}
-				tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max.Add(duration), activityPeriods[i+1].Min)
+				tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max, activityPeriod.Max.Add(duration))
+				tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max.Add(duration), activityPeriod.Max.Add(duration*2))
 			}
 		}
 	}

--- a/store/balance_events_store.go
+++ b/store/balance_events_store.go
@@ -103,8 +103,7 @@ func (s *balanceEventsStore) Summarize(interval types.SummaryInterval, activityP
 				if err != nil {
 					return nil, err
 				}
-				tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max, activityPeriod.Max.Add(duration))
-				tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max.Add(duration), activityPeriod.Max.Add(duration*2))
+				tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max, activityPeriod.Max.Add(duration*2))
 			}
 		}
 	}

--- a/usecase/cmd_handlers.go
+++ b/usecase/cmd_handlers.go
@@ -15,6 +15,7 @@ func NewCmdHandlers(cfg *config.Config, db *store.Store, c *client.Client) *CmdH
 		IndexerIndex:       indexing.NewIndexCmdHandler(cfg, db, c),
 		IndexerBackfill:    indexing.NewBackfillCmdHandler(cfg, db, c),
 		IndexerPurge:       indexing.NewPurgeCmdHandler(cfg, db, c),
+		IndexerReindex:     indexing.NewReindexCmdHandler(cfg, db, c),
 		IndexerSummarize:   indexing.NewSummarizeCmdHandler(cfg, db, c),
 		DecorateValidators: validator.NewDecorateCmdHandler(cfg, db, c),
 	}
@@ -25,6 +26,7 @@ type CmdHandlers struct {
 	IndexerIndex       *indexing.IndexCmdHandler
 	IndexerBackfill    *indexing.BackfillCmdHandler
 	IndexerPurge       *indexing.PurgeCmdHandler
+	IndexerReindex     *indexing.ReindexCmdHandler
 	IndexerSummarize   *indexing.SummarizeCmdHandler
 	DecorateValidators *validator.DecorateCmdHandler
 }

--- a/usecase/delegation/get_by_height.go
+++ b/usecase/delegation/get_by_height.go
@@ -1,6 +1,8 @@
 package delegation
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/figment-networks/oasishub-indexer/client"
 	"github.com/figment-networks/oasishub-indexer/store"
 )
@@ -19,20 +21,20 @@ func NewGetByHeightUseCase(db *store.Store, c *client.Client) *getByHeightUseCas
 
 func (uc *getByHeightUseCase) Execute(height *int64) (*ListView, error) {
 	// Get last indexed height
-	// mostRecentSynced, err := uc.db.Syncables.FindMostRecent()
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// lastH := mostRecentSynced.Height
+	mostRecentSynced, err := uc.db.Syncables.FindMostRecent()
+	if err != nil {
+		return nil, err
+	}
+	lastH := mostRecentSynced.Height
 
-	// // Show last synced height, if not provided
-	// if height == nil {
-	// 	height = &lastH
-	// }
+	// Show last synced height, if not provided
+	if height == nil {
+		height = &lastH
+	}
 
-	// if *height > lastH {
-	// 	return nil, errors.New("height is not indexed yet")
-	// }
+	if *height > lastH {
+		return nil, errors.New("height is not indexed yet")
+	}
 
 	res, err := uc.client.State.GetStakingByHeight(*height)
 	if err != nil {

--- a/usecase/delegation/get_by_height.go
+++ b/usecase/delegation/get_by_height.go
@@ -3,7 +3,6 @@ package delegation
 import (
 	"github.com/figment-networks/oasishub-indexer/client"
 	"github.com/figment-networks/oasishub-indexer/store"
-	"github.com/pkg/errors"
 )
 
 type getByHeightUseCase struct {
@@ -20,20 +19,20 @@ func NewGetByHeightUseCase(db *store.Store, c *client.Client) *getByHeightUseCas
 
 func (uc *getByHeightUseCase) Execute(height *int64) (*ListView, error) {
 	// Get last indexed height
-	mostRecentSynced, err := uc.db.Syncables.FindMostRecent()
-	if err != nil {
-		return nil, err
-	}
-	lastH := mostRecentSynced.Height
+	// mostRecentSynced, err := uc.db.Syncables.FindMostRecent()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// lastH := mostRecentSynced.Height
 
-	// Show last synced height, if not provided
-	if height == nil {
-		height = &lastH
-	}
+	// // Show last synced height, if not provided
+	// if height == nil {
+	// 	height = &lastH
+	// }
 
-	if *height > lastH {
-		return nil, errors.New("height is not indexed yet")
-	}
+	// if *height > lastH {
+	// 	return nil, errors.New("height is not indexed yet")
+	// }
 
 	res, err := uc.client.State.GetStakingByHeight(*height)
 	if err != nil {

--- a/usecase/indexing/reindex.go
+++ b/usecase/indexing/reindex.go
@@ -1,0 +1,46 @@
+package indexing
+
+import (
+	"context"
+	"github.com/figment-networks/oasishub-indexer/client"
+	"github.com/figment-networks/oasishub-indexer/config"
+	"github.com/figment-networks/oasishub-indexer/indexer"
+	"github.com/figment-networks/oasishub-indexer/store"
+)
+
+type reindexUseCase struct {
+	cfg    *config.Config
+	db     *store.Store
+	client *client.Client
+}
+
+func NewReindexUseCase(cfg *config.Config, db *store.Store, c *client.Client) *reindexUseCase {
+	return &reindexUseCase{
+		cfg:    cfg,
+		db:     db,
+		client: c,
+	}
+}
+
+type ReindexUseCaseConfig struct {
+	Parallel    bool
+	Force       bool
+	StartHeight int64
+	EndHeight   int64
+	TargetIds   []int64
+}
+
+func (uc *reindexUseCase) Execute(ctx context.Context, useCaseConfig ReindexUseCaseConfig) error {
+	indexingPipeline, err := indexer.NewPipeline(uc.cfg, uc.db, uc.client)
+	if err != nil {
+		return err
+	}
+
+	return indexingPipeline.Reindex(ctx, indexer.ReindexConfig{
+		Parallel: useCaseConfig.Parallel,
+		// Force:       useCaseConfig.Force,
+		StartHeight: useCaseConfig.StartHeight,
+		EndHeight:   useCaseConfig.EndHeight,
+		TargetIds:   useCaseConfig.TargetIds,
+	})
+}

--- a/usecase/indexing/reindex.go
+++ b/usecase/indexing/reindex.go
@@ -24,7 +24,6 @@ func NewReindexUseCase(cfg *config.Config, db *store.Store, c *client.Client) *r
 
 type ReindexUseCaseConfig struct {
 	Parallel    bool
-	Force       bool
 	StartHeight int64
 	EndHeight   int64
 	TargetIds   []int64
@@ -37,8 +36,7 @@ func (uc *reindexUseCase) Execute(ctx context.Context, useCaseConfig ReindexUseC
 	}
 
 	return indexingPipeline.Reindex(ctx, indexer.ReindexConfig{
-		Parallel: useCaseConfig.Parallel,
-		// Force:       useCaseConfig.Force,
+		Parallel:    useCaseConfig.Parallel,
 		StartHeight: useCaseConfig.StartHeight,
 		EndHeight:   useCaseConfig.EndHeight,
 		TargetIds:   useCaseConfig.TargetIds,

--- a/usecase/indexing/reindex_cmd_handler.go
+++ b/usecase/indexing/reindex_cmd_handler.go
@@ -1,0 +1,50 @@
+package indexing
+
+import (
+	"context"
+
+	"github.com/figment-networks/oasishub-indexer/client"
+	"github.com/figment-networks/oasishub-indexer/config"
+	"github.com/figment-networks/oasishub-indexer/store"
+	"github.com/figment-networks/oasishub-indexer/utils/logger"
+)
+
+type ReindexCmdHandler struct {
+	cfg    *config.Config
+	db     *store.Store
+	client *client.Client
+
+	useCase *reindexUseCase
+}
+
+func NewReindexCmdHandler(cfg *config.Config, db *store.Store, c *client.Client) *ReindexCmdHandler {
+	return &ReindexCmdHandler{
+		cfg:    cfg,
+		db:     db,
+		client: c,
+	}
+}
+
+func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, force bool, startHeight, endHeight int64, targetIds []int64) {
+	logger.Info("running reindex use case [handler=cmd]")
+
+	useCaseConfig := ReindexUseCaseConfig{
+		Parallel:    parallel,
+		Force:       force,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+		TargetIds:   targetIds,
+	}
+	err := h.getUseCase().Execute(ctx, useCaseConfig)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+}
+
+func (h *ReindexCmdHandler) getUseCase() *reindexUseCase {
+	if h.useCase == nil {
+		h.useCase = NewReindexUseCase(h.cfg, h.db, h.client)
+	}
+	return h.useCase
+}

--- a/usecase/indexing/reindex_cmd_handler.go
+++ b/usecase/indexing/reindex_cmd_handler.go
@@ -25,12 +25,11 @@ func NewReindexCmdHandler(cfg *config.Config, db *store.Store, c *client.Client)
 	}
 }
 
-func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, force bool, startHeight, endHeight int64, targetIds []int64) {
+func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, startHeight, endHeight int64, targetIds []int64) {
 	logger.Info("running reindex use case [handler=cmd]")
 
 	useCaseConfig := ReindexUseCaseConfig{
 		Parallel:    parallel,
-		Force:       force,
 		StartHeight: startHeight,
 		EndHeight:   endHeight,
 		TargetIds:   targetIds,


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=bdbddafa3a2f4e0d86795090fa6cae67)

Adds `reindex` command which lets one reindex from specified for specified target (previously had to run `backfill` which required updating indexer_config and reindexing entire chain).

`go run main.go -config config.example.json -cmd indexer:reindex --start_height 3672055 --target_ids 4`

Summarizing balance events wasn't possible across multiple threads. We stopped indexing balance events ~2 weeks ago after the node upgrade. When we release the rewards fix and start indexing balance events again, we will have two processes running (a worker, and this reindex command). The worker will be indexing balance events from the chain head, and the reindex command will be indexing from 2 weeks ago. The `summarize` job in the worker wasn't handling summarizing the events from 2 weeks ago.

activity periods passed to [summarize](https://github.com/figment-networks/oasishub-indexer/blob/master/store/balance_events_store.go#L82) from look like this:
```
 period |          min           |          max
--------+------------------------+------------------------
      1 | 2021-01-01 00:00:00-05 | 2021-01-04 00:00:00-05
      2 | 2021-06-14 00:00:00-04 | 2021-06-14 00:00:00-04
(2 rows)
``` 

Previously, large gap for period 1 was handled like this `tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max.Add(duration), activityPeriods[i+1].Min)`. This skips summarizing events on `2021-01-04 ` which are continuing to be collected, and instead captures only events between `2021-01-05` and  `2021-06-14`. Then when the indexer starts collecting for  `2021-01-05`, a balance summary entry is created capturing all indexed events for that date, however on subsequent summarize calls period 1 is now ` 1 | 2021-01-01 00:00:00-05 | 2021-01-05 00:00:00-05` so all further events indexed on `2021-01-05 `are ignored.
Changing the query to the following captures and summarizes  both events happening on `2021-01-05` and the following day `2021-01-06`:
```				
tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max, activityPeriod.Max.Add(duration))
 tx = tx.Or("time_bucket >= ? AND time_bucket < ?", activityPeriod.Max.Add(duration), activityPeriod.Max.Add(duration*2))
```

todo:
- !! need to update [purge_worker_interval](https://github.com/figment-networks/oasishub-indexer/blob/master/config/config.go#L45) in deploy config (on provisioning?) to something big like "1000h" (~5 weeks). Last indexed balance event was on `2021-06-11`, and purge job should NOT delete events older than 24h (current setting) otherwise We'll be deleting events faster than we summarize them. 

